### PR TITLE
Only update prerelease drafts when includePreReleases is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,6 @@ module.exports = (app, { getRouter }) => {
       targetCommitish,
       filterByCommitish,
       includePreReleases: shouldIncludePreReleases,
-      isPreRelease,
       tagPrefix,
     })
 

--- a/index.js
+++ b/index.js
@@ -185,6 +185,7 @@ module.exports = (app, { getRouter }) => {
       targetCommitish,
       filterByCommitish,
       includePreReleases: shouldIncludePreReleases,
+      isPreRelease,
       tagPrefix,
     })
 

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -30,7 +30,6 @@ const findReleases = async ({
   targetCommitish,
   filterByCommitish,
   includePreReleases,
-  isPreRelease,
   tagPrefix,
 }) => {
   let releaseCount = 0
@@ -70,7 +69,7 @@ const findReleases = async ({
     tagPrefix
   )
   const draftRelease = filteredReleases.find(
-    (r) => r.draft && r.prerelease === isPreRelease
+    (r) => r.draft && r.prerelease === includePreReleases
   )
   const lastRelease = sortedSelectedReleases[sortedSelectedReleases.length - 1]
 

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -30,6 +30,7 @@ const findReleases = async ({
   targetCommitish,
   filterByCommitish,
   includePreReleases,
+  isPreRelease,
   tagPrefix,
 }) => {
   let releaseCount = 0
@@ -68,7 +69,9 @@ const findReleases = async ({
     ),
     tagPrefix
   )
-  const draftRelease = filteredReleases.find((r) => r.draft)
+  const draftRelease = filteredReleases.find(
+    (r) => r.draft && r.prerelease === isPreRelease
+  )
   const lastRelease = sortedSelectedReleases[sortedSelectedReleases.length - 1]
 
   if (draftRelease) {

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -266,14 +266,12 @@ describe('releases', () => {
       }
       const targetCommitish = 'refs/heads/master'
       const filterByCommitish = ''
-      const isPrerelease = false
       const tagPrefix = 'test-'
 
       const { lastRelease } = await findReleases({
         context,
         targetCommitish,
         filterByCommitish,
-        isPrerelease,
         tagPrefix,
       })
       expect(lastRelease.tag_name).toEqual('test-1.0.1')
@@ -300,7 +298,6 @@ describe('releases', () => {
       const { lastRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
-        isPreRelease: false,
         tagPrefix: '',
       })
 
@@ -321,7 +318,7 @@ describe('releases', () => {
       const { draftRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
-        isPreRelease: false,
+        includePreReleases: false,
         tagPrefix: '',
       })
 
@@ -343,7 +340,6 @@ describe('releases', () => {
         context,
         targetCommitish: 'refs/heads/master',
         tagPrefix: '',
-        isPreRelease: true,
         includePreReleases: true,
       })
 

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -266,12 +266,14 @@ describe('releases', () => {
       }
       const targetCommitish = 'refs/heads/master'
       const filterByCommitish = ''
+      const isPrerelease = false
       const tagPrefix = 'test-'
 
       const { lastRelease } = await findReleases({
         context,
         targetCommitish,
         filterByCommitish,
+        isPrerelease,
         tagPrefix,
       })
       expect(lastRelease.tag_name).toEqual('test-1.0.1')
@@ -298,6 +300,7 @@ describe('releases', () => {
       const { lastRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
+        isPreRelease: false,
         tagPrefix: '',
       })
 
@@ -318,6 +321,7 @@ describe('releases', () => {
       const { draftRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
+        isPreRelease: false,
         tagPrefix: '',
       })
 
@@ -332,20 +336,27 @@ describe('releases', () => {
       paginateMock.mockResolvedValueOnce([
         { tag_name: 'v1.0.0', draft: true, prerelease: false },
         { tag_name: 'v1.0.1', draft: false, prerelease: false },
-        { tag_name: 'v1.0.2-rc.1', draft: false, prerelease: true },
+        { tag_name: 'v1.0.2-rc.1', draft: true, prerelease: true },
       ])
 
-      const { lastRelease } = await findReleases({
+      const { draftRelease, lastRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
         tagPrefix: '',
+        isPreRelease: true,
         includePreReleases: true,
       })
 
-      expect(lastRelease).toEqual({
+      expect(draftRelease).toEqual({
         tag_name: 'v1.0.2-rc.1',
-        draft: false,
+        draft: true,
         prerelease: true,
+      })
+
+      expect(lastRelease).toEqual({
+        tag_name: 'v1.0.1',
+        draft: false,
+        prerelease: false,
       })
     })
   })


### PR DESCRIPTION
Given the following releases:

| Tag/name | Draft | Prerelease |
|--------|--------|--------|
| v3.4.0 |   |  |
| v3.5.0-rc.4 |  | pre-release |
| v3.5.0 | draft |  |
| v3.5.0-rc.5 | draft | pre-release |

and a config:

```yaml
pre-release-identifier: rc
```
(implies `prerelease: true`)

I expect the `v3.5.0-rc.5` to be updated, and not `v3.5.0`, even though that draft release is newer/more recently updated or whatever. This allows me to maintain two configuration files for two draft releases, one for the next pre-release containing changes since the previous/current pre-release, and one for the next final release (with a minor version bump) containing the changes since the previous/current final release. 